### PR TITLE
MMA-1432 - Use Python 3 for local_scan

### DIFF
--- a/expy_local_scan.c
+++ b/expy_local_scan.c
@@ -216,7 +216,7 @@ static char *get_format_string(char *str, int need_newline)
         return str;
 
     /* Gotta make a new string, with '%'s and/or '\n' added */
-    newstr = store_get(len + percent_count + need_newline + 1);
+    newstr = store_get(len + percent_count + need_newline + 1, 0);
 
     for (p = str, q = newstr; *p; p++, q++)
         {

--- a/expy_local_scan.c
+++ b/expy_local_scan.c
@@ -44,7 +44,6 @@
 
 static BOOL    expy_enabled = TRUE;
 static uschar *expy_path_add = NULL;
-static uschar *expy_python3_path_add = NULL;
 static uschar *expy_exim_module = US"exim";
 static uschar *expy_scan_module = US"exim_local_scan";
 static uschar *expy_scan_function = US"local_scan";
@@ -55,7 +54,6 @@ optionlist local_scan_options[] =
     { "expy_enabled", opt_bool, &expy_enabled},
     { "expy_exim_module",  opt_stringptr, &expy_exim_module },
     { "expy_path_add",  opt_stringptr, &expy_path_add },
-    { "expy_python3_path_add",  opt_stringptr, &expy_python3_path_add },
     { "expy_scan_failure",  opt_stringptr, &expy_scan_failure},
     { "expy_scan_function",  opt_stringptr, &expy_scan_function },
     { "expy_scan_module",  opt_stringptr, &expy_scan_module },

--- a/expy_local_scan.c
+++ b/expy_local_scan.c
@@ -216,7 +216,7 @@ static char *get_format_string(char *str, int need_newline)
         return str;
 
     /* Gotta make a new string, with '%'s and/or '\n' added */
-    newstr = store_get(len + percent_count + need_newline + 1, 0);
+    newstr = store_get(len + percent_count + need_newline + 1,);
 
     for (p = str, q = newstr; *p; p++, q++)
         {

--- a/expy_local_scan.c
+++ b/expy_local_scan.c
@@ -216,7 +216,7 @@ static char *get_format_string(char *str, int need_newline)
         return str;
 
     /* Gotta make a new string, with '%'s and/or '\n' added */
-    newstr = store_get(len + percent_count + need_newline + 1,);
+    newstr = store_get(len + percent_count + need_newline + 1);
 
     for (p = str, q = newstr; *p; p++, q++)
         {

--- a/expy_local_scan_py3.c
+++ b/expy_local_scan_py3.c
@@ -10,10 +10,6 @@
 #include <Python.h>
 #include "local_scan.h"
 
-/* Replace strcmpic with strcasecmp for case-insensitive string comparison */
-#ifndef strcmpic
-#define strcmpic strcasecmp
-#endif
 
 static BOOL    expy_enabled = TRUE;
 static uschar *expy_path_add = NULL;

--- a/expy_local_scan_py3.c
+++ b/expy_local_scan_py3.c
@@ -709,9 +709,9 @@ int local_scan(int fd, uschar **return_text)
         if (!module)
             {
             *return_text = (uschar *) "Internal error";
-			log_write(0, LOG_PANIC, "Couldn't create %s module", expy_exim_module);
-			PyErr_Print();
-			return python_failure_return;
+            log_write(0, LOG_PANIC, "Couldn't create %s module", expy_exim_module);
+            PyErr_Print();
+            return python_failure_return;
             }
         Py_INCREF(module);  /* Optional: if you need to keep a reference */
         expy_exim_dict = PyModule_GetDict(module);  /* Borrowed reference */

--- a/expy_local_scan_py3.c
+++ b/expy_local_scan_py3.c
@@ -198,7 +198,7 @@ static char *get_format_string(char *str, int need_newline)
         return str;
 
     /* Gotta make a new string, with '%'s and/or '\n' added */
-    newstr = store_get(len + percent_count + need_newline + 1);
+    newstr = store_get(len + percent_count + need_newline + 1, 0);
 
     for (p = str, q = newstr; *p; p++, q++)
         {

--- a/expy_local_scan_py3.c
+++ b/expy_local_scan_py3.c
@@ -470,7 +470,7 @@ static PyObject *expy_child_open_exim(PyObject *self, PyObject *args)
          * An error occurred.
          */
         PyErr_Format(PyExc_OSError, "error %d", errno);
-	close(fd);
+        close(fd);
         return NULL;
     }
     close(fd);

--- a/expy_local_scan_py3.c
+++ b/expy_local_scan_py3.c
@@ -645,7 +645,7 @@ int local_scan(int fd, uschar **return_text)
     PyObject *original_recipients;
     PyObject *working_recipients;
 
-    log_write(0, LOG_MAIN, "Run with Python 3 local_scan");
+    log_write(0, LOG_MAIN, "Run with Python 3 local_scan env %s %s", PYTHON_LIB_PATH, PYTHON_INTERPRETER_PATH);
 
     if (!expy_enabled)
         return LOCAL_SCAN_ACCEPT;

--- a/expy_local_scan_py3.c
+++ b/expy_local_scan_py3.c
@@ -645,7 +645,7 @@ int local_scan(int fd, uschar **return_text)
     PyObject *original_recipients;
     PyObject *working_recipients;
 
-    log_write(0, LOG_MAIN, "Run with Python 3 local_scan env %s %s", PYTHON_LIB_PATH, PYTHON_INTERPRETER_PATH);
+    log_write(0, LOG_MAIN, "Run with Python 3 local_scan env %s", PYTHON_LIB_PATH);
 
     if (!expy_enabled)
         return LOCAL_SCAN_ACCEPT;

--- a/patch_exim_makefile.py
+++ b/patch_exim_makefile.py
@@ -23,12 +23,18 @@ CONFIG = {
         + EXTRALIBS,
         "LOCAL_SCAN_SOURCE": "expy_local_scan.c",
     },
-    "python3": {
+    "python3.9": {
         "CFLAGS": "-fPIC",
         "INCLUDE": "-I/usr/include/python3.9",
         "EXTRALIBS": "-lpython3.9 " + EXTRALIBS,
         "LOCAL_SCAN_SOURCE": "expy_local_scan_py3.c",
     },
+    "python3.11": {
+        "CFLAGS": "-fPIC",
+        "INCLUDE": "-I/usr/include/python3.11",
+        "EXTRALIBS": "-lpython3.11 " + EXTRALIBS,
+        "LOCAL_SCAN_SOURCE": "expy_local_scan_py3.c",
+    }
 }
 
 
@@ -75,7 +81,7 @@ if __name__ == "__main__":
     build_dir = sys.argv[1]
     source_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
     python_version = sys.argv[2]
-    if python_version not in ("python2", "python3"):
+    if python_version not in ("python2", "python3.9", "python3.11"):
         raise ValueError(
             "Invalid python_version: %r. Must be 'python2' or 'python3'."
             % python_version

--- a/patch_exim_makefile.py
+++ b/patch_exim_makefile.py
@@ -13,7 +13,17 @@ import os
 import os.path
 import shutil
 
-EXTRALIBS = "-lz -lm -lpthread -ldl -lutil -Xlinker -export-dynamic -Wl,-O1 -Wl,-Bsymbolic-functions"
+EXTRALIBS = " ".join(
+    "-lz",
+    "-lm",
+    "-lpthread",
+    "-ldl",
+    "-lutil",
+    "-Xlinker",
+    "-export-dynamic",
+    "-Wl,-O1",
+    "-Wl,-Bsymbolic-functions",
+)
 
 CONFIG = {
     "python2": {
@@ -34,7 +44,7 @@ CONFIG = {
         "INCLUDE": "-I/usr/include/python3.11",
         "EXTRALIBS": "-lpython3.11 " + EXTRALIBS,
         "LOCAL_SCAN_SOURCE": "expy_local_scan_py3.c",
-    }
+    },
 }
 
 
@@ -83,7 +93,7 @@ if __name__ == "__main__":
     python_version = sys.argv[2]
     if python_version not in ("python2", "python3.9", "python3.11"):
         raise ValueError(
-            "Invalid python_version: %r. Must be 'python2' or 'python3'."
-            % python_version
+            "Invalid python_version: %r. "
+            "Must be 'python2', 'python3.9' or 'python3.11'." % python_version
         )
     patch_makefile(source_dir, build_dir, python_version)

--- a/patch_exim_makefile.py
+++ b/patch_exim_makefile.py
@@ -72,5 +72,6 @@ if __name__ == "__main__":
     build_dir = sys.argv[1]
     source_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
     python_version = sys.argv[2]
-    assert python_version in ("python2", "python3")
+    if python_version not in ("python2", "python3"):
+        raise ValueError("Invalid python_version: %r. Must be 'python2' or 'python3'." % python_version)
     patch_makefile(source_dir, build_dir, python_version)

--- a/patch_exim_makefile.py
+++ b/patch_exim_makefile.py
@@ -35,7 +35,8 @@ CONFIG = {
 def patch_makefile(source_dir, build_dir, python_version):
     makefile_name = os.path.join(build_dir, "Local", "Makefile")
 
-    makefile = open(makefile_name, "r").readlines()
+    with open(makefile_name, "r") as fd:
+        makefile = fd.readlines()
 
     makefile.append("CFLAGS+=%s\n" % CONFIG[python_version]["CFLAGS"])
     makefile.append("INCLUDE+=%s\n" % CONFIG[python_version]["INCLUDE"])
@@ -49,7 +50,9 @@ def patch_makefile(source_dir, build_dir, python_version):
 
     # Write out updated makefile
     makefile = "".join(makefile)
-    open(makefile_name, "w").write(makefile)
+
+    with open(makefile_name, "w") as fd:
+        fd.write(makefile)
 
     # Symlink in C sourcefile
     shutil.copy(
@@ -73,5 +76,8 @@ if __name__ == "__main__":
     source_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
     python_version = sys.argv[2]
     if python_version not in ("python2", "python3"):
-        raise ValueError("Invalid python_version: %r. Must be 'python2' or 'python3'." % python_version)
+        raise ValueError(
+            "Invalid python_version: %r. Must be 'python2' or 'python3'."
+            % python_version
+        )
     patch_makefile(source_dir, build_dir, python_version)

--- a/patch_exim_makefile.py
+++ b/patch_exim_makefile.py
@@ -14,15 +14,17 @@ import os.path
 import shutil
 
 EXTRALIBS = " ".join(
-    "-lz",
-    "-lm",
-    "-lpthread",
-    "-ldl",
-    "-lutil",
-    "-Xlinker",
-    "-export-dynamic",
-    "-Wl,-O1",
-    "-Wl,-Bsymbolic-functions",
+    (
+        "-lz",
+        "-lm",
+        "-lpthread",
+        "-ldl",
+        "-lutil",
+        "-Xlinker",
+        "-export-dynamic",
+        "-Wl,-O1",
+        "-Wl,-Bsymbolic-functions",
+    )
 )
 
 CONFIG = {


### PR DESCRIPTION
### Why we need this

We need to make exim work with both Python 2 and Python 3 interpreter so we can convert local_scan.py

### Tickets/Links

MMA-1432

### How we fix it

Changelog:
* Adjust `expy_local_scan.c` to handle the `expy_python3_path_add` new config variable (it doesn't use it but if not handled it will fail.
* Adjust `expy_local_scan.c` to log what version of python interpreter it uses so we can easy debug.
* Create a new `expy_local_scan_py3.c` that is based on the old file but uses Python3 C API 
* Adjust `patch_exim_makefile.py` so it can patch exim makefile to embed either a Python 2 or a Python 3 interpreter in the binary. This will be used later in the build process to build 2 binaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Python 3 local_scan implementation (3.9/3.11) and updates the Makefile patcher to build with either Python 2 or Python 3; logs the active interpreter.
> 
> - **Local scan (C)**:
>   - **Python 3 implementation**: New `expy_local_scan_py3.c` using Python 3 C API, initializes module via `PyModule_Create`, handles headers/recipients, and logs environment; supports Python 3.9 and 3.11.
>   - **Python 2 module**: `expy_local_scan.c` now logs when running under Python 2.
> - **Build tooling**:
>   - **Makefile patcher**: Reworks `patch_exim_makefile.py` to accept `python2`, `python3.9`, or `python3.11`, applying version-specific `CFLAGS`, `INCLUDE`, `EXTRALIBS`, and selecting `LOCAL_SCAN_SOURCE` (`expy_local_scan.c` or `expy_local_scan_py3.c`).
>   - Writes flags with `+=` and copies the chosen C source into `Local/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbf53da3ad6b11c7f163e4668323aba88e10b327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->